### PR TITLE
DATAJPA-1377 - Add JpaRepository.getById for consistency, deprecated JpaRepository.g…

### DIFF
--- a/src/main/asciidoc/jpa.adoc
+++ b/src/main/asciidoc/jpa.adoc
@@ -789,7 +789,7 @@ Spring Data JPA takes the concept of a specification from Eric Evans' book, "`Do
 
 [source, java]
 ----
-public interface CustomerRepository extends CrudRepository<Customer, Long>, JpaSpecificationExecutor {
+public interface CustomerRepository extends CrudRepository<Customer, Long>, JpaSpecificationExecutor<Customer> {
  …
 }
 ----

--- a/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/JpaRepository.java
@@ -31,6 +31,8 @@ import org.springframework.data.repository.query.QueryByExampleExecutor;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Sander Krabbenborg
+ * @author Jesse Wouters
  */
 @NoRepositoryBean
 public interface JpaRepository<T, ID> extends PagingAndSortingRepository<T, ID>, QueryByExampleExecutor<T> {
@@ -71,17 +73,26 @@ public interface JpaRepository<T, ID> extends PagingAndSortingRepository<T, ID>,
 	/**
 	 * Saves an entity and flushes changes instantly.
 	 *
-	 * @param entity
+	 * @param entity entity to be saved. Must not be {@literal null}.
 	 * @return the saved entity
 	 */
 	<S extends T> S saveAndFlush(S entity);
+
+	/**
+	 * Saves all entities and flushes changes instantly.
+	 *
+	 * @param entities entities to be deleted. Must not be {@literal null}.
+	 * @return the saved entities
+	 * @since 2.5
+	 */
+	<S extends T> List<S> saveAllAndFlush(Iterable<S> entities);
 
 	/**
 	 * Deletes the given entities in a batch which means it will create a single query. This kind of operation leaves JPAs
 	 * first level cache and the database out of sync. Consider flushing the {@link EntityManager} before calling this
 	 * method.
 	 *
-	 * @param entities
+	 * @param entities entities to be deleted. Must not be {@literal null}.
 	 * @deprecated Use {@link #deleteAllInBatch(Iterable)} instead.
 	 */
 	@Deprecated
@@ -92,8 +103,8 @@ public interface JpaRepository<T, ID> extends PagingAndSortingRepository<T, ID>,
 	 * first level cache and the database out of sync. Consider flushing the {@link EntityManager} before calling this
 	 * method.
 	 *
-	 * @param entities
-	 * @since 3.0
+	 * @param entities entities to be deleted. Must not be {@literal null}.
+	 * @since 2.5
 	 */
 	void deleteAllInBatch(Iterable<T> entities);
 
@@ -102,8 +113,8 @@ public interface JpaRepository<T, ID> extends PagingAndSortingRepository<T, ID>,
 	 * Deletes the entities identified by the given ids using a single query. This kind of operation leaves JPAs first
 	 * level cache and the database out of sync. Consider flushing the {@link EntityManager} before calling this method.
 	 *
-	 * @param ids
-	 * @since 3.0
+	 * @param ids the ids of the entities to be deleted. Must not be {@literal null}.
+	 * @since 2.5
 	 */
 	void deleteAllByIdInBatch(Iterable<ID> ids);
 
@@ -121,8 +132,22 @@ public interface JpaRepository<T, ID> extends PagingAndSortingRepository<T, ID>,
 	 * @param id must not be {@literal null}.
 	 * @return a reference to the entity with the given identifier.
 	 * @see EntityManager#getReference(Class, Object) for details on when an exception is thrown.
+	 * @deprecated use {@link JpaRepository#getById(ID)} instead.
 	 */
+	@Deprecated
 	T getOne(ID id);
+
+	/**
+	 * Returns a reference to the entity with the given identifier. Depending on how the JPA persistence provider is
+	 * implemented this is very likely to always return an instance and throw an
+	 * {@link javax.persistence.EntityNotFoundException} on first access. Some of them will reject invalid identifiers
+	 * immediately.
+	 *
+	 * @param id must not be {@literal null}.
+	 * @return a reference to the entity with the given identifier.
+	 * @see EntityManager#getReference(Class, Object) for details on when an exception is thrown.
+	 */
+	T getById(ID id);
 
 	/*
 	 * (non-Javadoc)

--- a/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
+++ b/src/main/java/org/springframework/data/jpa/repository/support/SimpleJpaRepository.java
@@ -73,6 +73,8 @@ import org.springframework.util.Assert;
  * @author Jens Schauder
  * @author David Madden
  * @author Moritz Becker
+ * @author Sander Krabbenborg
+ * @author Jesse Wouters
  * @param <T> the type of the entity to handle
  * @param <ID> the type of the entity's identifier
  */
@@ -322,8 +324,20 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 	 * (non-Javadoc)
 	 * @see org.springframework.data.jpa.repository.JpaRepository#getOne(java.io.Serializable)
 	 */
+	@Deprecated
 	@Override
 	public T getOne(ID id) {
+
+		Assert.notNull(id, ID_MUST_NOT_BE_NULL);
+		return em.getReference(getDomainClass(), id);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.jpa.repository.JpaRepository#getById(java.io.Serializable)
+	 */
+	@Override
+	public T getById(ID id) {
 
 		Assert.notNull(id, ID_MUST_NOT_BE_NULL);
 		return em.getReference(getDomainClass(), id);
@@ -616,6 +630,20 @@ public class SimpleJpaRepository<T, ID> implements JpaRepositoryImplementation<T
 		for (S entity : entities) {
 			result.add(save(entity));
 		}
+
+		return result;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.jpa.repository.JpaRepository#saveAllAndFlush(java.lang.Iterable)
+	 */
+	@Transactional
+	@Override
+	public <S extends T> List<S> saveAllAndFlush(Iterable<S> entities) {
+
+		List<S> result = saveAll(entities);
+		flush();
 
 		return result;
 	}

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,43 @@
 Spring Data JPA Changelog
 =========================
 
+Changes in version 2.5.0-M4 (2021-02-18)
+----------------------------------------
+
+
+Changes in version 2.4.5 (2021-02-18)
+-------------------------------------
+
+
+Changes in version 2.5.0-M3 (2021-02-17)
+----------------------------------------
+* #2146 - SpecificationComposition reversed predicates.
+* #2127 - Update repository after GitHub issues migration.
+
+
+Changes in version 2.4.4 (2021-02-17)
+-------------------------------------
+* #2146 - SpecificationComposition reversed predicates.
+
+
+Changes in version 2.3.7.RELEASE (2021-02-17)
+---------------------------------------------
+* DATAJPA-1828 - Update CI jobs with Docker Login.
+* DATAJPA-1827 - @Modifing not supported by vavr integration.
+* #2149 - The 2.3.x build is broken.
+* #2146 - SpecificationComposition reversed predicates.
+* #2133 - Update copyright year to 2021.
+* #2129 - Missing anchor on "Custom Namespace Attributes" causes TOC to break.
+* #2127 - Update repository after GitHub issues migration.
+
+
+Changes in version 2.2.13.RELEASE (2021-02-17)
+----------------------------------------------
+* #2133 - Update copyright year to 2021.
+* #2129 - Missing anchor on "Custom Namespace Attributes" causes TOC to break.
+* #2127 - Update repository after GitHub issues migration.
+
+
 Changes in version 2.5.0-M2 (2021-01-13)
 ----------------------------------------
 * DATAJPA-1828 - Update CI jobs with Docker Login.
@@ -2133,6 +2170,12 @@ Changes in version 1.0.0.M2 (2011-03-24) - https://jira.springsource.org/browse/
 Changes in version 1.0.0.M1 (2011-02-10) - https://jira.springsource.org/browse/DATAJPA/fixforversion/11786
 ----------------------------------------
 * Moved JPA sepcific code from Hades into Spring Data JPA (functional equivalent of Hades 2.0.2) building on common functionality in Spring Data Commons
+
+
+
+
+
+
 
 
 

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data JPA 2.5 M2 (2021.0.0)
+Spring Data JPA 2.5 M4 (2021.0.0)
 Copyright (c) [2011-2019] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").
@@ -8,6 +8,8 @@ This product may include a number of subcomponents with
 separate copyright notices and license terms. Your use of the source
 code for the these subcomponents is subject to the terms and
 conditions of the subcomponent's license, as noted in the LICENSE file.
+
+
 
 
 

--- a/src/test/java/org/springframework/data/jpa/domain/sample/Customer.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/Customer.java
@@ -20,9 +20,12 @@ import javax.persistence.Id;
 
 /**
  * @author Oliver Gierke
+ * @author Patrice Blanchardie
  */
 @Entity
 public class Customer {
 
-	@Id Long id;
+    @Id Long id;
+
+    String name;
 }

--- a/src/test/java/org/springframework/data/jpa/domain/sample/Invoice.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/Invoice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.jpa.repository.query;
+package org.springframework.data.jpa.domain.sample;
 
-import org.springframework.test.context.ContextConfiguration;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 /**
- * @author Oliver Gierke
- * @author Jens Schauder
+ * @author Patrice Blanchardie
  */
-@ContextConfiguration("classpath:eclipselink.xml")
-class EclipseLinkQueryUtilsIntegrationTests extends QueryUtilsIntegrationTests {
+@Entity
+@Table(name = "INVOICES")
+public class Invoice {
 
-	int getNumberOfJoinsAfterCreatingAPath() {
-		return 1;
-	}
+	@Id Long id;
 
+	@ManyToOne(optional = false) Customer customer;
+
+	@ManyToOne Order order;
 }

--- a/src/test/java/org/springframework/data/jpa/domain/sample/InvoiceItem.java
+++ b/src/test/java/org/springframework/data/jpa/domain/sample/InvoiceItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.jpa.repository.query;
+package org.springframework.data.jpa.domain.sample;
 
-import org.springframework.test.context.ContextConfiguration;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 /**
- * @author Oliver Gierke
- * @author Jens Schauder
+ * @author Patrice Blanchardie
  */
-@ContextConfiguration("classpath:eclipselink.xml")
-class EclipseLinkQueryUtilsIntegrationTests extends QueryUtilsIntegrationTests {
+@Entity
+@Table(name = "INVOICE_ITEMS")
+public class InvoiceItem {
 
-	int getNumberOfJoinsAfterCreatingAPath() {
-		return 1;
-	}
+	@Id Long id;
 
+	@ManyToOne(optional = false) Invoice invoice;
 }

--- a/src/test/java/org/springframework/data/jpa/repository/AbstractPersistableIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/AbstractPersistableIntegrationTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.AbstractPersistable;
 import org.springframework.data.jpa.domain.sample.CustomAbstractPersistable;
+import org.springframework.data.jpa.domain.sample.User;
 import org.springframework.data.jpa.repository.sample.CustomAbstractPersistableRepository;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -36,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Thomas Darimont
  * @author Oliver Gierke
  * @author Jens Schauder
+ * @author Jesse Wouters
  */
 @Transactional
 @ExtendWith(SpringExtension.class)
@@ -63,6 +65,18 @@ public class AbstractPersistableIntegrationTests {
 		em.clear();
 
 		CustomAbstractPersistable proxy = repository.getOne(entity.getId());
+
+		assertThat(proxy).isEqualTo(proxy);
+	}
+
+	@Test // gh-1679
+	void equalsWorksForProxiedEntitiesUsingGetById() {
+
+		CustomAbstractPersistable entity = repository.saveAndFlush(new CustomAbstractPersistable());
+
+		em.clear();
+
+		CustomAbstractPersistable proxy = repository.getById(entity.getId());
 
 		assertThat(proxy).isEqualTo(proxy);
 	}

--- a/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
+++ b/src/test/java/org/springframework/data/jpa/repository/UserRepositoryTests.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -60,16 +59,16 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.ExampleMatcher.*;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
-import org.springframework.data.domain.ExampleMatcher.*;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.domain.sample.Address;
 import org.springframework.data.jpa.domain.sample.Role;
 import org.springframework.data.jpa.domain.sample.SpecialUser;
 import org.springframework.data.jpa.domain.sample.User;
-import org.springframework.data.jpa.repository.sample.SampleEvaluationContextExtension.SampleSecurityContextHolder;
 import org.springframework.data.jpa.repository.sample.UserRepository;
+import org.springframework.data.jpa.repository.sample.SampleEvaluationContextExtension.SampleSecurityContextHolder;
 import org.springframework.data.jpa.repository.sample.UserRepository.NameOnly;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -91,6 +90,8 @@ import com.google.common.base.Optional;
  * @author Kevin Peters
  * @author Jens Schauder
  * @author Andrey Kovalev
+ * @author Sander Krabbenborg
+ * @author Jesse Wouters
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:application-context.xml")
@@ -151,8 +152,8 @@ public class UserRepositoryTests {
 
 		flushTestUsers();
 
-		assertThat(repository.findAllById(asList(firstUser.getId(), secondUser.getId()))).contains(firstUser,
-				secondUser);
+		assertThat(repository.findAllById(asList(firstUser.getId(), secondUser.getId()))) //
+				.containsExactlyInAnyOrder(firstUser, secondUser);
 	}
 
 	@Test
@@ -166,13 +167,25 @@ public class UserRepositoryTests {
 	@Test
 	void savesCollectionCorrectly() throws Exception {
 
-		assertThat(repository.saveAll(asList(firstUser, secondUser, thirdUser))).hasSize(3).contains(firstUser,
-				secondUser, thirdUser);
+		assertThat(repository.saveAll(asList(firstUser, secondUser, thirdUser))) //
+				.containsExactlyInAnyOrder(firstUser, secondUser, thirdUser);
+	}
+
+	@Test // gh-2148
+	void savesAndFlushesCollectionCorrectly() {
+
+		assertThat(repository.saveAllAndFlush(asList(firstUser, secondUser, thirdUser))) //
+				.containsExactlyInAnyOrder(firstUser, secondUser, thirdUser);
 	}
 
 	@Test
 	void savingEmptyCollectionIsNoOp() throws Exception {
 		assertThat(repository.saveAll(new ArrayList<>())).isEmpty();
+	}
+
+	@Test // gh-2148
+	void savingAndFlushingEmptyCollectionIsNoOp() {
+		assertThat(repository.saveAllAndFlush(new ArrayList<>())).isEmpty();
 	}
 
 	@Test
@@ -987,6 +1000,15 @@ public class UserRepositoryTests {
 		assertThat(result).isEqualTo(firstUser);
 	}
 
+	@Test // gh-1679
+	void looksUpEntityReferenceUsingGetById() {
+
+		flushTestUsers();
+
+		User result = repository.getById(firstUser.getId());
+		assertThat(result).isEqualTo(firstUser);
+	}
+
 	@Test // DATAJPA-415
 	void invokesQueryWithVarargsParametersCorrectly() {
 
@@ -1099,6 +1121,20 @@ public class UserRepositoryTests {
 
 		assertThat(user.getFirstname()).isEqualTo(savedUser.getFirstname());
 		assertThat(user.getEmailAddress()).isEqualTo(savedUser.getEmailAddress());
+	}
+
+	@Test // gh-2148
+	void saveAllAndFlushShouldSupportReturningSubTypesOfRepositoryEntity() {
+
+		repository.deleteAll();
+		SpecialUser user = new SpecialUser();
+		user.setFirstname("Thomas");
+		user.setEmailAddress("thomas@example.org");
+
+		List<SpecialUser> savedUsers = repository.saveAllAndFlush(Collections.singletonList(user));
+
+		assertThat(user.getFirstname()).isEqualTo(savedUsers.get(0).getFirstname());
+		assertThat(user.getEmailAddress()).isEqualTo(savedUsers.get(0).getEmailAddress());
 	}
 
 	@Test // DATAJPA-218

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -22,6 +22,8 @@
 		<class>org.springframework.data.jpa.domain.sample.EmbeddedIdExampleDepartment</class>
 		<class>org.springframework.data.jpa.domain.sample.IdClassExampleEmployee</class>
 		<class>org.springframework.data.jpa.domain.sample.IdClassExampleDepartment</class>
+		<class>org.springframework.data.jpa.domain.sample.Invoice</class>
+		<class>org.springframework.data.jpa.domain.sample.InvoiceItem</class>
 		<class>org.springframework.data.jpa.domain.sample.Item</class>
 		<class>org.springframework.data.jpa.domain.sample.ItemSite</class>
 		<class>org.springframework.data.jpa.domain.sample.MailMessage</class>


### PR DESCRIPTION
…etOne.

Also added two new tests where getById is used instead of getOne.

Closes #1697

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
